### PR TITLE
Add a VALUES clause

### DIFF
--- a/src/mundaneum/examples.clj
+++ b/src/mundaneum/examples.clj
@@ -50,7 +50,7 @@
 ;; eye color popularity, grouping and counting as part of the query
 (query
  '[:select ?eyeColorLabel (count ?person :as ?count)
-   :where [[?person (wdt :eye-color) ?eyeColor] ]
+   :where [[?person (wdt :eye-color) ?eyeColor]]
    :group-by ?eyeColorLabel
    :order-by (desc ?count)])
 
@@ -123,12 +123,12 @@
   (->> (query
         (template [:select ?isto ?analogyLabel
                    :where [[~(symbol (str "wd:" a1)) ?isto ~(symbol (str "wd:" a2))]
-                           [~(symbol (str "wd:" b1)) ?isto ?analogy]
+                           [~(symbol (str "wd:" b1)) ?isto ?analogy]]]))
                            ;; tightens analogies by requiring that a2/b2 be of the same kind,
                            ;; but loses some interesting loose analogies:
                            ;; [~(symbol (str "wd:" a2)) (wdt :instance-of) ?kind]
                            ;; [?analogy (wdt :instance-of) ?kind]
-                           ]]))
+
        (map #(let [arc (label (:isto %))]
                (str (label a1)
                     " is <" arc "> to "
@@ -174,6 +174,7 @@
                       "Werner Herzog" "Björk" "George Saunders" "Feist" "Andrew Bird" "Sofia Coppola"])
      (map #(select-keys % [:workLabel :creatorLabel]))
      distinct)
+
 
 ;; How about something a bit more serious? Here we find drug-gene
 ;; product interactions and diseases for which these might be
@@ -230,6 +231,20 @@
 ;;  {:drugLabel "temsirolimus", :geneLabel "MTOR", :diseaseLabel "macrocephaly-intellectual disability-neurodevelopmental disorder-small thorax syndrome"}
 ;;  {:drugLabel "AIDA", :geneLabel "GRM1", :diseaseLabel "autosomal recessive spinocerebellar ataxia 13"}
 ;;  {:drugLabel "CPCCOEt", :geneLabel "GRM1", :diseaseLabel "autosomal recessive spinocerebellar ataxia 13"}]
+
+
+;; illustrate the use of :values
+(def inchikeys
+  #{"QFJCIRLUMZQUOT-HPLJOQBZSA-N"
+    "MTCJZZBQNCXKAP-KSYZLYKTSA-N"
+    "YNCMLFHHXWETLD-UHFFFAOYSA-N"})
+
+(query
+    '[:select ?compoundLabel
+      :where [[?compound (wdt :InChIKey) ?inchi]]
+      :values ?inchi inchikeys])
+
+;[{:compoundLabel "pyocyanine"} {:compoundLabel "sirolimus"} {:compoundLabel "formycin B"}]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Recently added lexical queries

--- a/src/mundaneum/examples.clj
+++ b/src/mundaneum/examples.clj
@@ -241,8 +241,8 @@
 
 (query
     '[:select ?compoundLabel
-      :where [[?compound (wdt :InChIKey) ?inchi]]
-      :values ?inchi inchikeys])
+      :where [[?compound (wdt :InChIKey) ?inchi]
+              :values ?inchi inchikeys]])
 
 ;[{:compoundLabel "pyocyanine"} {:compoundLabel "sirolimus"} {:compoundLabel "formycin B"}]
 

--- a/src/mundaneum/query.clj
+++ b/src/mundaneum/query.clj
@@ -98,10 +98,9 @@
                     (= :values token) (str "\n VALUES "
                                            (str " " (second q) " ")
                                            "{\n\t"
-                                           (if-let [e (binding [*ns* (the-ns 'mundaneum.query)]
-                                                        (eval (nth q 2)))]
+                                           (if-let [e  (eval (nth q 2))]
                                              (stringify-query e)
-                                             (throw (Exception. (str "could not evaluate symbol in value expansion " (pr-str token)))))
+                                             (throw (Exception. (str "could not evaluate symbol in value expansion " (pr-str (nth q 2))))))
                                            "\n}\n")
                     (= :where token) (str "\nWHERE {\n"
                                           (stringify-query (second q))

--- a/src/mundaneum/query.clj
+++ b/src/mundaneum/query.clj
@@ -84,8 +84,10 @@
                :union    (drop 2 q)
                :minus    (drop 2 q)
                :filter   (drop 2 q)
+               :values   (drop 3 q)
                :service  (drop 3 q)
                (rest q))
+
              (str out
                   (cond
                     (= :select token) "SELECT "
@@ -93,6 +95,14 @@
                     (= :filter token) (str " FILTER ("
                                            (stringify-query (second q))
                                            ")\n")
+                    (= :values token) (str "\n VALUES "
+                                           (str " " (second q) " ")
+                                           "{\n\t"
+                                           (if-let [e (binding [*ns* (the-ns 'mundaneum.query)]
+                                                        (eval (nth q 2)))]
+                                             (stringify-query e)
+                                             (throw (Exception. (str "could not evaluate symbol in value expansion " (pr-str token)))))
+                                           "\n}\n")
                     (= :where token) (str "\nWHERE {\n"
                                           (stringify-query (second q))
                                           ;; ;; always bring in the label service XXX breaks the new lexical queries!


### PR DESCRIPTION
PR addressing #13 

Couple of thoughts.

1. I had to use eval directly to interpret the symbol. Is there a safer way? Your other uses of eval are limited to the NS.
2. I just noticed the text edits for spacing parens - this was auto-changed by the editor (Cursive)