### PR TITLE
Fix deprecation warnings from clj build tool

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure   {:mvn/version "1.10.1"}
-        backtick              {:mvn/version "0.3.4"}
-        clj-time              {:mvn/version "0.12.2"}
-        clj-http              {:mvn/version "3.1.0"}
+        backtick/backtick     {:mvn/version "0.3.4"}
+        clj-time/clj-time     {:mvn/version "0.12.2"}
+        clj-http/clj-http     {:mvn/version "3.1.0"}
         org.clojure/data.json {:mvn/version "0.2.6"}
         org.wikidata.wdtk/wdtk-wikibaseapi     {:mvn/version "0.7.0"}
         org.eclipse.rdf4j/rdf4j-query          {:mvn/version "2.1.2"}


### PR DESCRIPTION
This change fixes these warnings:

```
DEPRECATED: Libs must be qualified, change clj-time => clj-time/clj-time (/Users/sritchie/.gitlibs/libs/jackrusher/mundaneum/84476918ee47b66a2d6128e1a90780e52fd2ae44/deps.edn)
DEPRECATED: Libs must be qualified, change backtick => backtick/backtick (/Users/sritchie/.gitlibs/libs/jackrusher/mundaneum/84476918ee47b66a2d6128e1a90780e52fd2ae44/deps.edn)
DEPRECATED: Libs must be qualified, change clj-http => clj-http/clj-http (/Users/sritchie/.gitlibs/libs/jackrusher/mundaneum/84476918ee47b66a2d6128e1a90780e52fd2ae44/deps.edn)
```