### PR TITLE
Fix basics notebook

### DIFF
--- a/notebooks/basics.clj
+++ b/notebooks/basics.clj
@@ -285,7 +285,7 @@
 (binding [*default-language* :ga]
   (query `{:select [?areaLabel]
            :where [[~(entity "Éire")
-                    ~(wdt :contains-administrative-territorial-entity)
+                    ~(wdt :contains-the-administrative-territorial-entity)
                     ?area]]
            :limit 50}))
 


### PR DESCRIPTION
This PR fixes the _basics_ notebook, which failed to run for me, throwing "Syntax errors exist in the WHERE clause!" (`:com.yetanalytics.flint/invalid-query`). 

Specifically, the "administrative territories within the Republic of Ireland" query failed because the property `:contains-administrative-territorial-entity` doesn't exist, causing the macro to produce a `[:wd/Q27 nil ?area]` WHERE clause. A (cursory) search didn't turn up any news of a name change, but `:contains-the-administrative-territorial-entity` works in the "Clerk runs" sense and appears correct.