### PR TITLE
Add user agent

### DIFF
--- a/src/mundaneum/query.clj
+++ b/src/mundaneum/query.clj
@@ -16,6 +16,8 @@
     (deref *default-language*)
     *default-language*))
 
+(def ^:dynamic *default-user-agent* "Mundaneum (+https://github.com/jackrusher/mundaneum)")
+
 (def prefixes
   "RDF prefixes automatically supported by the WikiData query service."
   {:bd "<http://www.bigdata.com/rdf#>"
@@ -90,7 +92,8 @@
   [sparql-text]
   (mapv clojurize-values
         (-> (http/get "https://query.wikidata.org/sparql"
-                      {:query-params {:query sparql-text
+                      {:headers {"User-Agent" *default-user-agent*}
+                       :query-params {:query sparql-text
                                       :format "json"}})
             :body
             (json/read-str :key-fn keyword)
@@ -193,7 +196,8 @@
    (search (default-language) text))
   ([lang text]
    (->> (-> (http/get "https://www.wikidata.org/w/api.php"
-                      {:query-params {:action "wbsearchentities"
+                      {:headers {"User-Agent" *default-user-agent*}
+                       :query-params {:action "wbsearchentities"
                                       :search text
                                       :language (name lang)
                                       :uselang (name lang)
@@ -212,7 +216,8 @@
   (let [item-id (name item)]
     ((keyword item-id)
      (-> (http/get (str "https://www.wikidata.org/wiki/Special:EntityData/" item-id ".json")
-                   {:query-params {:format "json"}})
+                   {:headers {"User-Agent" *default-user-agent*}
+                    :query-params {:format "json"}})
          :body
          (json/read-str :key-fn keyword)
          :entities))))


### PR DESCRIPTION
# Error

On 25/August we noticed a behavior change in Wikidata. Suddenly, `(entity "James Joyce")` returned a `403`:

```
1. Unhandled clojure.lang.ExceptionInfo
   status: 403
   {:request-time 815, :request {:user-info nil, :headers {"accept-encoding" "gzip, deflate"}, :server-port nil, :url "https://query.wikidata.org/sparql", ...}, :http-client #object[jdk.internal.net.http.HttpClientFacade 0x5962a5d2 "jdk.internal.net.http.HttpClientImpl@3c607807(1)"], :headers {":status" "403", "content-length" "92", "content-type" "text/plain", "server" "HAProxy", "x-analytics" "", ...}, :status 403, ...}
```

The same is true for `search` and `entity-data`.

# Changes

It seems that Wikidata is now enforcing the Data [Access best practices](https://www.wikidata.org/wiki/Wikidata%3AData_access) point number 1:

> Follow the `User-Agent` policy – send a good `User-Agent` header.

So I added `:headers {"User-Agent" *default-user-agent*}`.

Now `(entity "James Joyce")` &rArr; `:wd/Q6882` as is documented. `search` and `entity-data` were similarly adjusted and tested.

# Additional Header Concerns

## Accept Encoding

Wikidata's Data [Access best practices](https://www.wikidata.org/wiki/Wikidata%3AData_access) also requsets:

> Follow the robot policy: send `Accept-Encoding: gzip,deflate` and don’t make too many requests at once.

Care was taken to test that the addition of the header did not overwrite hato defaults: `:headers {"accept-encoding" "gzip, deflate"}`. Testing shows that the default behavior is to merge headers and not overwrite.

## Accept

We may want to move the *format* from the URL query string to the dynamically-defined [request header](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#SPARQL_endpoint) to allow users of Mundaneum easy overwrite. This is not part of this PR.

